### PR TITLE
B-Matchmaking-23.2-Build_core_match_loop

### DIFF
--- a/campusgg-backend/src/matchmaking/engine/game-tiers.config.ts
+++ b/campusgg-backend/src/matchmaking/engine/game-tiers.config.ts
@@ -1,0 +1,78 @@
+/**
+ * @file game-tiers.config.ts
+ * @description Sub-issue 23.2 — Game Tier Classification
+ *
+ * Maps every supported game to a tier that determines the required
+ * group size for matchmaking. This is the single source of truth for
+ * "how many players make a match" — the engine consults this config
+ * instead of hard-coding sizes.
+ *
+ * To add a new game:
+ *   1. Add the title to `SupportedGame` in player-matchmaking.schema.ts
+ *   2. Add an entry to `GAME_TIER_MAP` below
+ *   3. Done — the engine will auto-route to the correct group size
+ *
+ * Follows Open/Closed principle: extend by adding data, not by modifying
+ * engine control flow.
+ */
+
+import type { SupportedGame } from '../schemas/player-matchmaking.schema.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tier definitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The two structural tiers on CampusGG.
+ *
+ * - `Competitive` : team-based ranked games (5-player groups)
+ * - `Casual`      : co-op / social games   (2-player groups)
+ */
+export type GameTier = 'Competitive' | 'Casual';
+
+/**
+ * Maps each tier to its required group size.
+ * This is the only place group sizes are defined.
+ */
+export const TIER_GROUP_SIZE: Readonly<Record<GameTier, number>> = {
+  Competitive: 5,
+  Casual: 2,
+} as const;
+
+/**
+ * Maps every supported game to its tier.
+ * If a game is not in this map, the engine will reject it at enqueue time.
+ */
+export const GAME_TIER_MAP: Readonly<Record<SupportedGame, GameTier>> = {
+  'CS2':               'Competitive',
+  'Valorant':          'Competitive',
+  'League of Legends': 'Competitive',
+  'Dota':              'Competitive',
+  'OW2':               'Competitive',
+  'Rocket League':     'Competitive',
+  'It Takes Two':      'Casual',
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Derived helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the tier for a given game.
+ * Throws if the game is unknown (should never happen with strict typing).
+ */
+export function getTier(game: SupportedGame): GameTier {
+  const tier = GAME_TIER_MAP[game];
+  if (!tier) {
+    throw new Error(`[CampusGG] Unknown game: "${game}". Add it to GAME_TIER_MAP.`);
+  }
+  return tier;
+}
+
+/**
+ * Returns the required number of players for a match in the given game.
+ * This is the value the engine loop checks against the candidate pool size.
+ */
+export function getGroupSize(game: SupportedGame): number {
+  return TIER_GROUP_SIZE[getTier(game)];
+}

--- a/campusgg-backend/src/matchmaking/engine/match-strategy.interface.ts
+++ b/campusgg-backend/src/matchmaking/engine/match-strategy.interface.ts
@@ -1,0 +1,75 @@
+/**
+ * @file match-strategy.interface.ts
+ * @description Sub-issue 23.2 — Strategy Pattern Interface
+ *
+ * Defines the contract that all scoring strategies must implement.
+ * The engine is strategy-agnostic: it only calls `scoreGroup()` and
+ * compares the result against a configurable threshold.
+ *
+ * For 23.2, a DummyStrategy is provided so the engine loop can be
+ * tested end-to-end before the real multi-dimensional scorer (23.3)
+ * is implemented.
+ *
+ * Follows:
+ *   - Strategy Pattern   : engine delegates scoring to an injected strategy
+ *   - Dependency Inversion: engine depends on the abstraction, not the impl
+ *   - Interface Segregation: one method, one responsibility
+ */
+
+import type { PlayerMatchmakingInput } from '../schemas/player-matchmaking.schema.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Strategy interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Contract for a matchmaking scoring strategy.
+ *
+ * Implementors receive a candidate group of players and return a single
+ * compatibility score in [0.0, 1.0]. The engine then decides whether
+ * the score meets the acceptance threshold.
+ *
+ * @example
+ * class RealStrategy implements MatchStrategy {
+ *   scoreGroup(group: ReadonlyArray<PlayerMatchmakingInput>): number {
+ *     // multi-dimensional weighted scoring math here
+ *   }
+ * }
+ */
+export interface MatchStrategy {
+  /**
+   * Evaluate how well a candidate group of players fits together.
+   *
+   * @param group - The candidate group (2 or 5 players, depending on tier).
+   * @returns     - A score in [0.0, 1.0] where 1.0 is a perfect match.
+   */
+  scoreGroup(group: ReadonlyArray<PlayerMatchmakingInput>): number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dummy implementation (23.2 placeholder)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Default score returned by the dummy strategy. */
+const DUMMY_SCORE = 0.85;
+
+/**
+ * A no-op strategy that always returns a fixed score (0.85).
+ *
+ * Purpose:
+ *   - Lets us test the full engine loop (enqueue → partition → group → handoff)
+ *     without waiting for the real scoring math.
+ *   - The 0.85 value is above any reasonable threshold, so every candidate
+ *     group will pass — proving the routing and grouping logic works.
+ *
+ * Will be replaced by the real scorer in Sub-issue 23.3.
+ */
+export class DummyStrategy implements MatchStrategy {
+  /**
+   * Always returns DUMMY_SCORE (0.85), regardless of group composition.
+   * @param _group - Unused; present to satisfy the interface contract.
+   */
+  scoreGroup(_group: ReadonlyArray<PlayerMatchmakingInput>): number {
+    return DUMMY_SCORE;
+  }
+}

--- a/campusgg-backend/src/matchmaking/engine/matchmaking-engine.ts
+++ b/campusgg-backend/src/matchmaking/engine/matchmaking-engine.ts
@@ -1,0 +1,249 @@
+/**
+ * @file matchmaking-engine.ts
+ * @description Sub-issue 23.2 — Core Matchmaking Engine
+ *
+ * Implements the queue management loop that:
+ *   1. Accepts players via `enqueue()`
+ *   2. Hard-partitions the queue by game
+ *   3. Dynamically determines group size from the game's tier
+ *   4. Delegates scoring to an injected MatchStrategy
+ *   5. Emits MatchGroup payloads via the `onMatchFound` callback
+ *
+ * Boundary responsibilities (what this class does NOT do):
+ *   - Does NOT implement scoring math (deferred to 23.3 via Strategy Pattern)
+ *   - Does NOT manage lobby state (owned by the Lobby service)
+ *   - Does NOT persist data (stateless in-memory queue)
+ *
+ * Design principles:
+ *   - Single Responsibility : queue plumbing only
+ *   - Open/Closed           : new games/tiers require zero engine changes
+ *   - Dependency Inversion  : depends on MatchStrategy interface, not impl
+ *   - Interface Segregation : one callback, one strategy method
+ */
+
+import * as crypto from 'crypto';
+
+import type { PlayerMatchmakingInput, SupportedGame } from '../schemas/player-matchmaking.schema.js';
+import type { MatchGroup } from '../schemas/match-group.schema.js';
+import type { MatchStrategy } from './match-strategy.interface.js';
+import { getGroupSize, getTier } from './game-tiers.config.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Default minimum score a candidate group must achieve to be accepted.
+ * Can be overridden per-engine instance via the constructor.
+ */
+const DEFAULT_SCORE_THRESHOLD = 0.70;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Callback type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Signature for the match-found callback.
+ * The engine calls this with an immutable MatchGroup whenever a group passes
+ * the score threshold. The Lobby service (or any consumer) hooks into this.
+ */
+export type OnMatchFoundCallback = (matchGroup: MatchGroup) => void;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Engine options
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Constructor options for the MatchmakingEngine.
+ * All fields are optional — sensible defaults are provided.
+ */
+export interface MatchmakingEngineOptions {
+  /**
+   * The scoring strategy to use when evaluating candidate groups.
+   * Injected via constructor — enables swapping DummyStrategy for the real
+   * scorer without touching engine code.
+   */
+  readonly strategy: MatchStrategy;
+
+  /**
+   * Callback fired whenever a match group is successfully formed.
+   * Defaults to a no-op if not provided.
+   */
+  readonly onMatchFound?: OnMatchFoundCallback;
+
+  /**
+   * Minimum acceptable score from the strategy.
+   * Groups scoring below this are rejected and their players stay in queue.
+   * Defaults to DEFAULT_SCORE_THRESHOLD (0.70).
+   */
+  readonly scoreThreshold?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Engine implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The core matchmaking engine.
+ *
+ * Usage:
+ * ```ts
+ * const engine = new MatchmakingEngine({
+ *   strategy: new DummyStrategy(),
+ *   onMatchFound: (group) => console.log('Match!', group),
+ * });
+ *
+ * players.forEach((p) => engine.enqueue(p));
+ * const results = engine.processQueue();
+ * ```
+ */
+export class MatchmakingEngine {
+  // ── Internal state ──────────────────────────────────────────────────────
+
+  /**
+   * The player queue, keyed by game title.
+   * Each game gets its own isolated sub-queue (hard partitioning).
+   * Using a Map preserves insertion order within each partition.
+   */
+  private readonly queue: Map<SupportedGame, PlayerMatchmakingInput[]> = new Map();
+
+  /** Injected scoring strategy (DummyStrategy for 23.2, real scorer for 23.3). */
+  private readonly strategy: MatchStrategy;
+
+  /** Callback invoked for every accepted match group. */
+  private readonly onMatchFound: OnMatchFoundCallback;
+
+  /** Minimum score for a group to be accepted. */
+  private readonly scoreThreshold: number;
+
+  // ── Constructor ─────────────────────────────────────────────────────────
+
+  constructor(options: MatchmakingEngineOptions) {
+    this.strategy       = options.strategy;
+    this.onMatchFound   = options.onMatchFound ?? (() => {});
+    this.scoreThreshold = options.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Add a player to the matchmaking queue.
+   *
+   * The player is routed to the sub-queue for their `game` field.
+   * Duplicate user IDs within the same game partition are silently rejected
+   * to prevent double-queuing.
+   *
+   * @param player - A validated PlayerMatchmakingInput payload.
+   */
+  enqueue(player: PlayerMatchmakingInput): void {
+    const { game, userId } = player;
+
+    // Initialise the sub-queue for this game if it doesn't exist yet
+    if (!this.queue.has(game)) {
+      this.queue.set(game, []);
+    }
+
+    const gameQueue = this.queue.get(game)!;
+
+    // Guard: prevent duplicate enqueue
+    if (gameQueue.some((p) => p.userId === userId)) {
+      console.warn(`[Engine] Duplicate enqueue rejected: ${userId} already in ${game} queue.`);
+      return;
+    }
+
+    gameQueue.push(player);
+  }
+
+  /**
+   * Process the entire queue once.
+   *
+   * For each game partition:
+   *   1. Look up the required group size from the game's tier
+   *   2. While enough players remain, slice a candidate group
+   *   3. Score the group via the injected strategy
+   *   4. If the score meets the threshold, emit a MatchGroup and
+   *      remove those players from the queue
+   *   5. If the score is too low, skip this group (players stay queued
+   *      for the next processing cycle)
+   *
+   * Returns all successfully formed MatchGroups for observability.
+   *
+   * @returns Array of MatchGroup payloads that were handed off.
+   */
+  processQueue(): MatchGroup[] {
+    const formedGroups: MatchGroup[] = [];
+
+    // Iterate over every game partition independently (hard partitioning)
+    for (const [game, players] of this.queue.entries()) {
+      const groupSize = getGroupSize(game);
+      const tier      = getTier(game);
+
+      // Keep forming groups while we have enough players
+      while (players.length >= groupSize) {
+        // Take the first `groupSize` players (FIFO — respects queue order)
+        const candidates = players.slice(0, groupSize);
+
+        // Delegate scoring to the injected strategy
+        const score = this.strategy.scoreGroup(candidates);
+
+        if (score >= this.scoreThreshold) {
+          // ── Match accepted ────────────────────────────────────────────
+          const matchGroup: MatchGroup = {
+            groupId   : `grp_${crypto.randomUUID()}`,
+            game,
+            tier,
+            userIds   : candidates.map((p) => p.userId),
+            score,
+            matchedAt : new Date().toISOString(),
+          };
+
+          // Remove matched players from the front of the queue
+          players.splice(0, groupSize);
+
+          // Fire the handoff callback (Lobby service hook point)
+          this.onMatchFound(matchGroup);
+
+          // Track for return value
+          formedGroups.push(matchGroup);
+        } else {
+          // ── Match rejected ────────────────────────────────────────────
+          // With the DummyStrategy (0.85 > 0.70), this branch is never
+          // hit — but the plumbing is in place for the real scorer.
+          // Break to avoid an infinite loop on the same failing group.
+          console.log(
+            `[Engine] Group for ${game} scored ${score.toFixed(2)} — ` +
+            `below threshold ${this.scoreThreshold.toFixed(2)}. Skipping.`,
+          );
+          break;
+        }
+      }
+    }
+
+    return formedGroups;
+  }
+
+  // ── Observability helpers ────────────────────────────────────────────────
+
+  /**
+   * Returns a snapshot of the current queue sizes per game.
+   * Useful for logging, dashboards, and health checks.
+   */
+  getQueueSnapshot(): Record<string, number> {
+    const snapshot: Record<string, number> = {};
+    for (const [game, players] of this.queue.entries()) {
+      snapshot[game] = players.length;
+    }
+    return snapshot;
+  }
+
+  /**
+   * Returns the total number of players across all game queues.
+   */
+  getTotalQueueSize(): number {
+    let total = 0;
+    for (const players of this.queue.values()) {
+      total += players.length;
+    }
+    return total;
+  }
+}

--- a/campusgg-backend/src/matchmaking/engine/run-engine-fallback.py
+++ b/campusgg-backend/src/matchmaking/engine/run-engine-fallback.py
@@ -1,0 +1,154 @@
+﻿#!/usr/bin/env python3
+"""
+run-engine-fallback.py  --  Sub-issue 23.2 Smoke Test (Python fallback)
+
+Mirrors the TypeScript run-engine.ts logic using pure Python to validate
+the engine design when Node.js is not available on the local machine.
+
+This script:
+  1. Loads mock_players.json
+  2. Partitions players by game
+  3. Looks up group sizes from tier config
+  4. Applies DummyStrategy (always 0.85)
+  5. Forms groups and emits MatchGroup payloads
+
+Run:
+    py src/matchmaking/engine/run-engine-fallback.py
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+MOCK_DATA_PATH = Path(__file__).parents[4] / "mock-data" / "mock_players.json"
+SCORE_THRESHOLD = 0.70
+DUMMY_SCORE = 0.85
+
+# ── Tier config (mirrors game-tiers.config.ts) ───────────────────────────────
+
+GAME_TIER_MAP: dict[str, str] = {
+    "CS2":               "Competitive",
+    "Valorant":          "Competitive",
+    "League of Legends": "Competitive",
+    "Dota":              "Competitive",
+    "OW2":               "Competitive",
+    "Rocket League":     "Competitive",
+    "It Takes Two":      "Casual",
+}
+
+TIER_GROUP_SIZE: dict[str, int] = {
+    "Competitive": 5,
+    "Casual":      2,
+}
+
+def get_group_size(game: str) -> int:
+    tier = GAME_TIER_MAP.get(game)
+    if tier is None:
+        raise ValueError(f"Unknown game: {game}")
+    return TIER_GROUP_SIZE[tier]
+
+def get_tier(game: str) -> str:
+    tier = GAME_TIER_MAP.get(game)
+    if tier is None:
+        raise ValueError(f"Unknown game: {game}")
+    return tier
+
+# ── Load mock data ───────────────────────────────────────────────────────────
+
+raw = MOCK_DATA_PATH.read_text(encoding="utf-8")
+players: list[dict] = json.loads(raw)
+
+print()
+print("\u2554" + "\u2550" * 62 + "\u2557")
+print("\u2551  CampusGG \u2014 Matchmaking Engine Smoke Test (Sub-issue 23.2)  \u2551")
+print("\u255a" + "\u2550" * 62 + "\u255d")
+print(f"  Loaded {len(players)} players from mock_players.json")
+print()
+
+# ── Partition by game (hard partitioning) ────────────────────────────────────
+
+queue: dict[str, list[dict]] = {}
+for p in players:
+    game = p["game"]
+    if game not in queue:
+        queue[game] = []
+    queue[game].append(p)
+
+print("\u2500\u2500 Queue state before processing " + "\u2500" * 30)
+total_queued = sum(len(v) for v in queue.values())
+print(f"  Total players queued: {total_queued}")
+for game, q in queue.items():
+    print(f"    {game}: {len(q)} players (tier: {get_tier(game)}, group size: {get_group_size(game)})")
+print()
+
+# ── Process queue ────────────────────────────────────────────────────────────
+
+print("\u2500\u2500 Processing queue " + "\u2500" * 43)
+
+formed_groups: list[dict] = []
+group_counter = 0
+
+for game, game_queue in queue.items():
+    group_size = get_group_size(game)
+    tier = get_tier(game)
+
+    while len(game_queue) >= group_size:
+        candidates = game_queue[:group_size]
+        score = DUMMY_SCORE  # DummyStrategy
+
+        if score >= SCORE_THRESHOLD:
+            group_counter += 1
+            group_id = f"grp_{uuid.uuid4()}"
+            user_ids = [c["userId"] for c in candidates]
+            match_group = {
+                "groupId":   group_id,
+                "game":      game,
+                "tier":      tier,
+                "userIds":   user_ids,
+                "score":     score,
+                "matchedAt": datetime.now(timezone.utc).isoformat(),
+            }
+
+            # Remove matched players
+            del game_queue[:group_size]
+
+            # Handoff callback (console.log mock)
+            truncated = [uid[:16] + "..." for uid in user_ids]
+            print(
+                f"  [MATCH #{group_counter:02d}] "
+                f"{game} ({tier}, {len(user_ids)}p) | "
+                f"score: {score:.2f} | "
+                f"group: {group_id[:16]}..."
+            )
+            print(f"           players: [{', '.join(truncated)}]")
+
+            formed_groups.append(match_group)
+        else:
+            print(
+                f"  [Engine] Group for {game} scored {score:.2f} \u2014 "
+                f"below threshold {SCORE_THRESHOLD:.2f}. Skipping."
+            )
+            break
+
+print()
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+total_matched = sum(len(g["userIds"]) for g in formed_groups)
+remaining = sum(len(v) for v in queue.values())
+
+print("\u2500\u2500 Summary " + "\u2500" * 52)
+print(f"  Total groups formed   : {len(formed_groups)}")
+print(f"  Total players matched : {total_matched}")
+print(f"  Remaining in queue    : {remaining}")
+
+for game, q in queue.items():
+    if len(q) > 0:
+        print(f"    {game}: {len(q)} leftover (not enough for a full group)")
+
+print()
+print("  Engine loop verified. Ready for Sub-issue 23.3 (real scoring).")
+print()

--- a/campusgg-backend/src/matchmaking/engine/run-engine.ts
+++ b/campusgg-backend/src/matchmaking/engine/run-engine.ts
@@ -1,0 +1,114 @@
+/**
+ * @file run-engine.ts
+ * @description Sub-issue 23.2 — Engine Execution & Smoke Test Script
+ *
+ * Loads mock_players.json, enqueues every player into the MatchmakingEngine
+ * with a DummyStrategy, processes the queue, and logs every MatchGroup that
+ * is handed off — proving the end-to-end loop works.
+ *
+ * Run:
+ *   npx ts-node src/matchmaking/engine/run-engine.ts
+ *
+ * Or with Python runner fallback (see run-engine-fallback.py)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { PlayerMatchmakingInput } from '../schemas/player-matchmaking.schema.js';
+import type { MatchGroup } from '../schemas/match-group.schema.js';
+import { DummyStrategy } from './match-strategy.interface.js';
+import { MatchmakingEngine } from './matchmaking-engine.js';
+import { getGroupSize, getTier } from './game-tiers.config.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Load mock data
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_DATA_PATH = path.resolve(__dirname, '../../../../mock-data/mock_players.json');
+const rawJson = fs.readFileSync(MOCK_DATA_PATH, 'utf-8');
+const mockPlayers: PlayerMatchmakingInput[] = JSON.parse(rawJson);
+
+console.log('');
+console.log('╔══════════════════════════════════════════════════════════════╗');
+console.log('║  CampusGG — Matchmaking Engine Smoke Test (Sub-issue 23.2)  ║');
+console.log('╚══════════════════════════════════════════════════════════════╝');
+console.log(`  Loaded ${mockPlayers.length} players from mock_players.json`);
+console.log('');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Configure the engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Tracks total groups formed for the summary. */
+let totalGroupsFormed = 0;
+
+/**
+ * Mock `onMatchFound` callback — simulates what the Lobby service would do.
+ * In production, this would emit an event / call the Lobby microservice.
+ */
+function handleMatchFound(group: MatchGroup): void {
+  totalGroupsFormed++;
+
+  const playerList = group.userIds
+    .map((id) => id.slice(0, 16) + '...')  // truncate UUIDs for readability
+    .join(', ');
+
+  console.log(
+    `  [MATCH #${String(totalGroupsFormed).padStart(2, '0')}] ` +
+    `${group.game} (${group.tier}, ${group.userIds.length}p) | ` +
+    `score: ${group.score.toFixed(2)} | ` +
+    `group: ${group.groupId.slice(0, 16)}...`,
+  );
+  console.log(`           players: [${playerList}]`);
+}
+
+const engine = new MatchmakingEngine({
+  strategy: new DummyStrategy(),
+  onMatchFound: handleMatchFound,
+  scoreThreshold: 0.70,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Enqueue all players
+// ─────────────────────────────────────────────────────────────────────────────
+
+for (const player of mockPlayers) {
+  engine.enqueue(player);
+}
+
+console.log('── Queue state before processing ──────────────────────────────');
+console.log(`  Total players queued: ${engine.getTotalQueueSize()}`);
+const preSnapshot = engine.getQueueSnapshot();
+for (const [game, count] of Object.entries(preSnapshot)) {
+  console.log(`    ${game}: ${count} players (tier: ${getTier(game as any)}, group size: ${getGroupSize(game as any)})`);
+}
+console.log('');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Process the queue
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('── Processing queue ───────────────────────────────────────────');
+const formedGroups = engine.processQueue();
+console.log('');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Summary
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('── Summary ────────────────────────────────────────────────────');
+console.log(`  Total groups formed : ${formedGroups.length}`);
+console.log(`  Total players matched : ${formedGroups.reduce((sum, g) => sum + g.userIds.length, 0)}`);
+console.log(`  Remaining in queue  : ${engine.getTotalQueueSize()}`);
+
+const postSnapshot = engine.getQueueSnapshot();
+for (const [game, count] of Object.entries(postSnapshot)) {
+  if (count > 0) {
+    console.log(`    ${game}: ${count} leftover (not enough for a full group)`);
+  }
+}
+
+console.log('');
+console.log('  Engine loop verified. Ready for Sub-issue 23.3 (real scoring).');
+console.log('');

--- a/campusgg-backend/src/matchmaking/index.ts
+++ b/campusgg-backend/src/matchmaking/index.ts
@@ -1,16 +1,16 @@
-﻿/**
+/**
  * @file index.ts  (matchmaking module barrel)
  * @description Public API surface for the matchmaking module.
  *
  * Consumers (engine, controllers, tests) should import from this barrel:
  *
  *   import type { PlayerMatchmakingInput } from '../matchmaking';
- *   import { generateMockPlayers }         from '../matchmaking';
+ *   import { MatchmakingEngine, DummyStrategy } from '../matchmaking';
  *
  * This keeps internal folder structure an implementation detail.
  */
 
-// Schema — types and interfaces (engine interface contract)
+// ── 23.1: Schema — types and interfaces (engine interface contract) ─────────
 export type {
   SupportedGame,
   CS2Role,
@@ -23,5 +23,17 @@ export type {
   PlayerMatchmakingInput,
 } from './schemas/player-matchmaking.schema.js';
 
-// Mock generator — dev/test utility, NOT imported in production bundles
+export type { MatchGroup } from './schemas/match-group.schema.js';
+
+// ── 23.2: Engine — core loop, strategy, tiers ──────────────────────────────
+export type { GameTier } from './engine/game-tiers.config.js';
+export { GAME_TIER_MAP, TIER_GROUP_SIZE, getTier, getGroupSize } from './engine/game-tiers.config.js';
+
+export type { MatchStrategy } from './engine/match-strategy.interface.js';
+export { DummyStrategy } from './engine/match-strategy.interface.js';
+
+export type { OnMatchFoundCallback, MatchmakingEngineOptions } from './engine/matchmaking-engine.js';
+export { MatchmakingEngine } from './engine/matchmaking-engine.js';
+
+// ── Mock generator — dev/test utility, NOT imported in production bundles ───
 export { generateMockPlayers } from './mock/mock-player.generator.js';

--- a/campusgg-backend/src/matchmaking/schemas/match-group.schema.ts
+++ b/campusgg-backend/src/matchmaking/schemas/match-group.schema.ts
@@ -1,0 +1,57 @@
+/**
+ * @file match-group.schema.ts
+ * @description Sub-issue 23.2 — Match Group Output Schema
+ *
+ * Defines the shape of the data that the matchmaking engine emits
+ * when it successfully forms a group. This is the handoff contract
+ * between the engine and the downstream lobby-creation service.
+ *
+ * The engine's only job is to produce MatchGroup objects.
+ * It does NOT create or manage lobby state — that responsibility
+ * belongs to the Lobby service (owned by another teammate).
+ */
+
+import type { SupportedGame } from './player-matchmaking.schema.js';
+import type { GameTier } from '../engine/game-tiers.config.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The payload emitted by the engine when a match is found.
+ *
+ * Downstream consumers (Lobby service, analytics, notifications) receive
+ * this shape via the `onMatchFound` callback.
+ *
+ * All fields are `readonly` — the engine hands off an immutable snapshot.
+ */
+export interface MatchGroup {
+  /**
+   * Unique identifier for this match group.
+   * Format: `grp_<uuid-v4>` — namespaced to avoid ID collisions with users.
+   */
+  readonly groupId: string;
+
+  /** The game this group was matched for. */
+  readonly game: SupportedGame;
+
+  /** The tier classification (for downstream routing / logging). */
+  readonly tier: GameTier;
+
+  /**
+   * Ordered array of user IDs in this group.
+   * Length is always equal to the tier's required group size
+   * (5 for Competitive, 2 for Casual).
+   */
+  readonly userIds: ReadonlyArray<string>;
+
+  /**
+   * The compatibility score assigned by the active MatchStrategy.
+   * Range: [0.0, 1.0]. Included for observability and analytics.
+   */
+  readonly score: number;
+
+  /** ISO-8601 timestamp of when the match was formed. */
+  readonly matchedAt: string;
+}

--- a/campusgg-backend/src/matchmaking/schemas/player-matchmaking.schema.ts
+++ b/campusgg-backend/src/matchmaking/schemas/player-matchmaking.schema.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @file player-matchmaking.schema.ts
  * @description Sub-issue 23.1 — Interface Contract (Data Schema)
  *
@@ -24,7 +24,14 @@
  * Supported games on the platform.
  * Extend this union as new titles are onboarded.
  */
-export type SupportedGame = 'CS2' | 'Valorant' | 'Rocket League' | 'League of Legends';
+export type SupportedGame =
+  | 'CS2'
+  | 'Valorant'
+  | 'Rocket League'
+  | 'League of Legends'
+  | 'Dota'
+  | 'OW2'
+  | 'It Takes Two';
 
 /**
  * CS2-specific in-game roles.


### PR DESCRIPTION
Closes #31 
For issue #23

Built the core matchmaking engine routing loop and queue management.
Implemented hard partitioning by game and dynamic group sizing.
Added a decoupled onMatchFound event to hand off MatchGroups to the Lobby service.
Set up the Strategy Pattern interface with a placeholder dummy score.